### PR TITLE
SGD Shuffle

### DIFF
--- a/src/NN.cpp
+++ b/src/NN.cpp
@@ -37,6 +37,7 @@
 #include "NN.h"
 #include <iomanip>
 #include <sstream>
+#include <algorithm>
 
 
 
@@ -333,7 +334,11 @@ bool Neural_network::train()
   int debug_count = 0;
   bool early_stop = false;
   int nval = 0;
-
+  vector <int> order(systems.size());
+  for (int i = 0; i < systems.size(); i++) {
+      order[i] = i;
+  }
+  bool SGD = params.SGD();
   while (!optimizer->is_converged() && !optimizer->is_checkpoint()) {
     REAL debug_error = 0.0;
     this->SSE = 0.0;
@@ -343,7 +348,13 @@ bool Neural_network::train()
     nval = 0.0;
     my_dOutput_dParameters.assign(my_dOutput_dParameters.size(), 0);
     //this->bernoulli_sample(this->params.dropout());
-    for (int i_sys=0; i_sys<systems.size(); i_sys++) {
+    //for (int i_sys=0; i_sys<systems.size(); i_sys++) {
+    int i_sys;
+    if (SGD) {
+        std::random_shuffle(order.begin(),order.end());
+    }
+    for (int i=0; i<order.size(); i++) {
+      i_sys = order[i];
       if(systems.at(i_sys)->train == "train") {
         output = 0.0;
         vector<REAL> temp_dOutput_dParameters(Nparams, 0.0);

--- a/src/Potential.cpp
+++ b/src/Potential.cpp
@@ -616,11 +616,13 @@ REAL Potential::train()
 
   this->syncronize();
   int i_sys;
+  int nval;
   while (!opt->is_converged()) {
 
     REAL SSE = 0;
     REAL vSSE = 0;
     gradient.assign(Ntotal_params, 0.0);
+    nval = 0;
     if (SGD) {
         std::random_shuffle(order.begin(),order.end());
     }
@@ -656,10 +658,11 @@ REAL Potential::train()
 
         Error = (output + output_mean) - systems[i_sys]->properties.target();
         vSSE += Error*Error;
+        nval++;
       }
 
     }
-    opt->set_val_sse(vSSE,Nval);
+    opt->set_val_sse(vSSE,nval);
     opt->update_network(SSE, gradient);
 
 

--- a/src/Potential.cpp
+++ b/src/Potential.cpp
@@ -606,7 +606,11 @@ REAL Potential::train()
   opt = new Optimizer(mpi,params,Ntrain);
   opt->set_early_stop(this->early_stop);
   init_optimizer();
-
+  vector <int> order(systems.size());
+  for (int i = 0; i < systems.size(); i++) {
+      order[i] = i;
+  }
+  bool SGD = params.SGD();
   REAL Error;
   REAL output;
 
@@ -617,8 +621,13 @@ REAL Potential::train()
     REAL SSE = 0;
     REAL vSSE = 0;
     gradient.assign(Ntotal_params, 0.0);
-
-    for (int i_sys=0; i_sys<systems.size(); i_sys++) {
+    if (SGD) {
+        std::random_shuffle(order.begin(),order.end());
+    }
+    //for (int i_sys=0; i_sys<systems.size(); i_sys++) {
+    int i_sys;
+    for (int i=0; i<order.size(); i++) {
+      i_sys = order[i];
       if (systems[i_sys]->train == "train") {
         output = 0;
         for (int atom=0; atom<systems[i_sys]->structure.Natom; atom++) {

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -250,9 +250,14 @@ void Setup::read_input (string filename)
       F.my_norm_cd = true;
       F.my_norm_cd_val = real_value;
     } else if (key == "sgd") {
-      Line >> int_value;
-      F.my_SGD = true;
-      F.my_SGD_cnt = int_value;
+      Line >> string_value;
+      if (string_value == "true" || string_value == "t" || string_value == "1") {
+        F.my_SGD = true;
+      } else {
+          F.my_SGD = false;
+      }
+      //F.my_SGD = true;
+      //F.my_SGD_cnt = int_value;
     } else if (key == "nsave") {
       Line >> int_value;
       F.my_Nbackup = int_value;


### PR DESCRIPTION
This is a minor pull request to the final version 1.1. 

Fixes: 

1. Specifying sgd = true in the input file will shuffle the training examples during training, enabling sgd-like training. 
2. In training a potential, if "val" is specified for a data example, it will now properly display the validation error (see input_file in doc). 